### PR TITLE
feat: restrict `useForm` hook to accept non-nested zod schema only

### DIFF
--- a/src/hooks/useForm/useForm.hook.ts
+++ b/src/hooks/useForm/useForm.hook.ts
@@ -5,12 +5,13 @@ import {
   FormFieldValues,
   FormSchema,
   FormTouchedState,
+  NonNestedZodSchema,
 } from "../../types/form.type";
 import { zodValidate } from "../../utils/form/form.util";
 
 type UseFormOptions<TZodSchema extends z.ZodTypeAny> = {
-  schema: TZodSchema;
-  initialFormValues: FormSchema<TZodSchema>;
+  schema: NonNestedZodSchema<TZodSchema>;
+  initialFormValues: FormFieldValues<TZodSchema>;
   initialTouchedState: FormTouchedState<TZodSchema>;
 };
 
@@ -38,7 +39,7 @@ export default function useForm<TZodSchema extends z.ZodTypeAny>(
   // #region INTERNAL FORM STATE
 
   const [formData, setFormData] =
-    useState<FormSchema<TZodSchema>>(initialFormValues);
+    useState<FormFieldValues<TZodSchema>>(initialFormValues);
   const [isTouched, setIsTouched] =
     useState<FormTouchedState<TZodSchema>>(initialTouchedState);
 

--- a/src/types/common.type.ts
+++ b/src/types/common.type.ts
@@ -1,0 +1,91 @@
+/**
+ * Generic type to transform deep nested object type
+ * so that each keys in the object will have a new type
+ * of TNew
+ *
+ * example :
+ *
+ * type Information = {
+ *   name: string;
+ *   address: {
+ *     street: string
+ *     zipCode: number
+ *   }
+ * }
+ *
+ * If we want to convert all fields in the Information type
+ * to have a boolean type, then we can do this
+ *
+ * type NewInformation = MapNestedObjects<Information, boolean>
+ *
+ * Which is the same as
+ *
+ * type NewInformation = {
+ *   name: boolean;
+ *   address: {
+ *     street: boolean
+ *     zipCode: boolean
+ *   }
+ * }
+ *
+ *
+ */
+export type MapNestedObjects<T extends object, TNew> = {
+  [K in keyof T]: T[K] extends object ? MapNestedObjects<T[K], TNew> : TNew;
+};
+
+/**
+ * Generic type that accepts an object type
+ * and will return the original object type if all
+ * object keys are not of object type
+ *
+ * Example :
+ *
+ * type ValidType = {
+ *   one: string;
+ *   two: string;
+ * }
+ *
+ * CheckNestedObject<Valid> will return
+ * type ValidType = {
+ *   one: string;
+ *   two: string;
+ * }
+ *
+ * Whereas
+ *
+ * type InValidType = {
+ *   one: string;
+ *   nested: {
+ *     a: number;
+ *     b: string;
+ *   }
+ * }
+ *
+ * CheckNestedObject<InValidType> will return
+ *
+ * type InValidType = {
+ *   one: never;
+ *   nested: {
+ *     a: never;
+ *     b: never;
+ *   }
+ * }
+ */
+export type CheckNestedObject<T extends object> = {
+  [K in keyof T]: T[K] extends object ? never : T[K];
+};
+
+/**
+ * Generic type to check whether two given types are stricly equal.
+ * In this type expression, the type variable T is not explicitly
+ * defined or constrained outside the function type.
+ * Instead, it's inferred based on the context in which Equals<X, Y> is used
+ *
+ * Source: https://github.com/Microsoft/TypeScript/issues/27024#issuecomment-421529650
+ */
+export type Equals<X, Y> = (<T>() => T extends X ? 1 : 2) extends <
+  T
+>() => T extends Y ? 1 : 2
+  ? true
+  : false;

--- a/src/types/common.type.ts
+++ b/src/types/common.type.ts
@@ -66,10 +66,7 @@ export type MapNestedObjects<T extends object, TNew> = {
  *
  * type InValidType = {
  *   one: never;
- *   nested: {
- *     a: never;
- *     b: never;
- *   }
+ *   nested: never
  * }
  */
 export type CheckNestedObject<T extends object> = {

--- a/src/types/form.type.ts
+++ b/src/types/form.type.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { CheckNestedObject, Equals, MapNestedObjects } from "./common.type";
 
 /**
  * Generic type for errors returned from zod safe parsing the form schema
@@ -16,18 +17,19 @@ export type FormSchema<TZodSchema extends z.ZodTypeAny> = z.infer<TZodSchema>;
 /**
  * Generic type that accepts a valid zod schema and returns
  * mapped type for form input values where all form fields have string type
+ * including all schema keys with nested object.
  */
-export type FormFieldValues<TZodSchema extends z.ZodTypeAny> = {
-  [K in keyof FormSchema<TZodSchema>]: string;
-};
+export type FormFieldValues<TZodSchema extends z.ZodTypeAny> = MapNestedObjects<
+  FormSchema<TZodSchema>,
+  string
+>;
 
 /**
  * Generic type that accepts a valid zod schema and returns a
  * mapped boolean typescript object type from the schema keys
  */
-export type FormTouchedState<TZodSchema extends z.ZodTypeAny> = {
-  [K in keyof FormSchema<TZodSchema>]: boolean;
-};
+export type FormTouchedState<TZodSchema extends z.ZodTypeAny> =
+  MapNestedObjects<FormSchema<TZodSchema>, boolean>;
 
 /**
  * Generic type for errors returned from zod safe parsing the form schema
@@ -35,3 +37,11 @@ export type FormTouchedState<TZodSchema extends z.ZodTypeAny> = {
 export type FormErrorState<TZodSchema extends z.ZodTypeAny> = FieldErrors<
   FormSchema<TZodSchema>
 >;
+
+/** Generic type to check whether a given zod schema has nested fields or not */
+export type NonNestedZodSchema<TZodSchema extends z.ZodTypeAny> = Equals<
+  CheckNestedObject<FormSchema<TZodSchema>>,
+  FormSchema<TZodSchema>
+> extends true
+  ? TZodSchema
+  : never;


### PR DESCRIPTION
This PR adds multiple typings to ensure that the generic `useForm` hook can only be used with non-nested zod schema only. This simplification is done so that the `useForm` hook will not produce unwanted errors, that will definitely appear with the current implementation, when user use a nested zod schema for a form.

A non-nested zod schema is something that look like this:

```ts
const loginFormSchema = z.object({
  username: z.string(),
  password: z.string(),
});
```

Whereas a nested zod schema is something that look like this:

```ts
const nestedSchema = z.object({
  name: z.string(),
  address: z.object({
    streetName: z.string(),
    houseNumber: z.number()
  })
})
```

Since handling deeply nested shema is too much for me now, I think this is the best way to safe-guarding the hook so that it will work as expected. 