### PR TITLE
feat: refactor form error handling

### DIFF
--- a/src/hooks/use-login-form/use-login-form.hook.ts
+++ b/src/hooks/use-login-form/use-login-form.hook.ts
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo } from "react";
 import { z } from "zod";
-import { FormSchema } from "../../types/form.type";
-import { zodValidate } from "../../utils/form/form.util";
+import { FormSchema, FormTouchedState } from "../../types/form.type";
+import { getFieldError } from "../../utils/form/form.util";
 import useForm from "../use-form/use-form.hook";
 
 export const loginFormSchema = z.object({
@@ -16,9 +16,7 @@ export const loginFormSchema = z.object({
 });
 
 export type LoginFormSchema = FormSchema<typeof loginFormSchema>;
-type LoginFormTouchedState = {
-  [K in keyof LoginFormSchema]: boolean;
-};
+type LoginFormTouchedState = FormTouchedState<typeof loginFormSchema>;
 
 export default function useLoginForm() {
   // #region FORM STATE & HANDLERS
@@ -59,26 +57,27 @@ export default function useLoginForm() {
 
   // #region ERROR VALIDATIONS
 
-  const errors = useMemo(
-    () => zodValidate(loginFormSchema, form.values.formData),
+  const usernameError = useMemo(
+    () =>
+      getFieldError(
+        loginFormSchema,
+        form.values.formData,
+        form.values.isTouched,
+        "username"
+      ),
     [form.values]
   );
 
-  const usernameError = useMemo(() => {
-    if (errors.username && form.values.isTouched.username) {
-      return errors.username[0];
-    }
-
-    return undefined;
-  }, [errors, form.values.isTouched.username]);
-
-  const passwordError = useMemo(() => {
-    if (errors.password && form.values.isTouched.password) {
-      return errors.password[0];
-    }
-
-    return undefined;
-  }, [errors, form.values.isTouched.password]);
+  const passwordError = useMemo(
+    () =>
+      getFieldError(
+        loginFormSchema,
+        form.values.formData,
+        form.values.isTouched,
+        "password"
+      ),
+    [form.values]
+  );
 
   // #endregion
 
@@ -86,7 +85,6 @@ export default function useLoginForm() {
     values: {
       isTouched: form.values.isTouched,
       formState: form.values.formData,
-      errors,
       usernameError,
       passwordError,
     },

--- a/src/utils/form/form.util.test.ts
+++ b/src/utils/form/form.util.test.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
-import { zodValidate } from "./form.util";
+import { FormSchema, FormTouchedState } from "../../types/form.type";
+import { getFieldError, zodValidate } from "./form.util";
 
 const loginFormSchema = z.object({
   username: z
@@ -44,6 +45,58 @@ describe("form util", () => {
       const errors = zodValidate(loginFormSchema, validValues);
 
       expect(errors.username).toBeUndefined();
+    });
+  });
+
+  describe("getFieldError", () => {
+    const schema = z.object({
+      username: z.string().nonempty({ message: "Username is required" }),
+      password: z.string().nonempty({ message: "Password is required" }),
+    });
+
+    it("returns the error message for a touched field with an error", () => {
+      const values: FormSchema<typeof schema> = {
+        username: "",
+        password: "123",
+      };
+
+      const touchedState: FormTouchedState<typeof schema> = {
+        username: true,
+        password: true,
+      };
+
+      const error = getFieldError(schema, values, touchedState, "username");
+      expect(error).toEqual("Username is required");
+    });
+
+    it("returns undefined for a field with no error", () => {
+      const values: FormSchema<typeof schema> = {
+        username: "",
+        password: "123",
+      };
+
+      const touchedState: FormTouchedState<typeof schema> = {
+        username: false,
+        password: true,
+      };
+
+      const error = getFieldError(schema, values, touchedState, "password");
+      expect(error).toBeUndefined();
+    });
+
+    it("returns undefined for a field that is not touched", () => {
+      const values: FormSchema<typeof schema> = {
+        username: "",
+        password: "123",
+      };
+
+      const touchedState: FormTouchedState<typeof schema> = {
+        username: false,
+        password: true,
+      };
+
+      const error = getFieldError(schema, values, touchedState, "username");
+      expect(error).toBeUndefined();
     });
   });
 });

--- a/src/utils/form/form.util.ts
+++ b/src/utils/form/form.util.ts
@@ -1,5 +1,9 @@
 import { z } from "zod";
-import { FieldErrors, FormSchema } from "../../types/form.type";
+import {
+  FieldErrors,
+  FormSchema,
+  FormTouchedState,
+} from "../../types/form.type";
 
 /**
  * Validates values against a Zod schema and returns any validation errors.
@@ -11,7 +15,7 @@ import { FieldErrors, FormSchema } from "../../types/form.type";
  *
  * @returns {FieldErrors<FormSchema<TZodSchema>>}
  *   - An object containing the field errors,
- *   where each field is a key and the value is either a single string or an array of strings.
+ *   where each field is a key and the value is an array of strings.
  *   - If there are no validation errors, an empty object is returned.
  */
 export function zodValidate<TZodSchema extends z.ZodTypeAny>(
@@ -27,4 +31,40 @@ export function zodValidate<TZodSchema extends z.ZodTypeAny>(
   return result.error.flatten().fieldErrors as FieldErrors<
     FormSchema<TZodSchema>
   >;
+}
+
+/**
+ * Get the error message for a specific form field.
+ *
+ * @template TZodSchema - The Zod schema type for the form.
+ * @param {z.ZodType<any>} schema - The Zod schema for the form.
+ * @param {FormSchema} values - The form values.
+ * @param {FormTouchedState} touchedState - The touched state of form fields.
+ * @param {keyof FormSchema} field - The field name to retrieve the error for.
+ * @returns {string | undefined} - The error message for the field, or undefined if no error or field is not touched.
+ */
+export function getFieldError<
+  TZodSchema extends z.ZodTypeAny,
+  TField extends keyof FormSchema<TZodSchema>
+>(
+  schema: TZodSchema,
+  values: FormSchema<TZodSchema>,
+  touchedState: FormTouchedState<TZodSchema>,
+  field: TField
+): string | undefined {
+  const errors = zodValidate(schema, values);
+
+  if (
+    errors !== undefined &&
+    Object.keys(errors).length !== 0 &&
+    touchedState[field]
+  ) {
+    const fieldError = errors[field];
+
+    if (fieldError && fieldError.length > 0) {
+      return fieldError[0];
+    }
+  }
+
+  return undefined;
 }

--- a/src/utils/form/form.util.ts
+++ b/src/utils/form/form.util.ts
@@ -3,6 +3,7 @@ import {
   FieldErrors,
   FormSchema,
   FormTouchedState,
+  NonNestedZodSchema,
 } from "../../types/form.type";
 
 /**
@@ -47,7 +48,7 @@ export function getFieldError<
   TZodSchema extends z.ZodTypeAny,
   TField extends keyof FormSchema<TZodSchema>
 >(
-  schema: TZodSchema,
+  schema: NonNestedZodSchema<TZodSchema>,
   values: FormSchema<TZodSchema>,
   touchedState: FormTouchedState<TZodSchema>,
   field: TField


### PR DESCRIPTION
In this PR, three things are done:

- created new function to get error for each field in the form
- added test cases for the function
- refactor error handling in `use-login-form` hook